### PR TITLE
fix: Using FName for comparisons instead of strings

### DIFF
--- a/tsw-controller-mod/ue4ss-mod/src/dllmain.cpp
+++ b/tsw-controller-mod/ue4ss-mod/src/dllmain.cpp
@@ -254,7 +254,8 @@ class TSWControllerMod : public RC::CppUserModBase
 
     static void on_process_event_pre_callback(Unreal::UObject* context, Unreal::UFunction* function, void* params)
     {
-        if (function->GetName() != STR("Tick"))
+        static auto NAME_Tick = Unreal::FName(STR("Tick"));
+        if (function->GetNamePrivate() != NAME_Tick)
         {
             /* only run on ticks to prevent clogging*/
             return;
@@ -392,7 +393,7 @@ class TSWControllerMod : public RC::CppUserModBase
             VirtualHIDComponent_GetCurrentlyChangingControllerParams get_currently_changing_controller_params{};
             context.Context->ProcessEvent(get_currently_changing_controller_func, &get_currently_changing_controller_params);
             /* don't do anything if it's a none identifier, there is no controller or it's not the player controller */
-            if (input_identifier->ToString() == STR("None") || !get_currently_changing_controller_params.Controller ||
+            if (*input_identifier == Unreal::NAME_None || !get_currently_changing_controller_params.Controller ||
                 !TSWControllerMod::is_player_controller(get_currently_changing_controller_params.Controller))
             {
                 return;


### PR DESCRIPTION
It's highly recommended to do your comparisons using `FName` instead of strings when possible to avoid potentially lengthy string comparisons, especially in high-traffic functions like ProcessEvent.
This PR does so in two places where you already had FNames that you were unnecessarily converting to strings.

Note that I haven't tested these changes, even to see if it builds, because I currently don't have the ability to do so.
If it doesn't work, it should be trivial to fix.